### PR TITLE
Support queued event handlers

### DIFF
--- a/app/Events/AnalysisHasCompletedEvent.php
+++ b/app/Events/AnalysisHasCompletedEvent.php
@@ -12,6 +12,7 @@
 
 namespace StyleCI\StyleCI\Events;
 
+use Illuminate\Queue\SerializesModels;
 use StyleCI\StyleCI\Models\Commit;
 
 /**
@@ -21,6 +22,8 @@ use StyleCI\StyleCI\Models\Commit;
  */
 class AnalysisHasCompletedEvent
 {
+    use SerializesModels;
+
     /**
      * The commit that was analysed.
      *

--- a/app/Events/RepoWasDisabledEvent.php
+++ b/app/Events/RepoWasDisabledEvent.php
@@ -12,6 +12,7 @@
 
 namespace StyleCI\StyleCI\Events;
 
+use Illuminate\Queue\SerializesModels;
 use StyleCI\StyleCI\Models\Repo;
 
 /**
@@ -21,6 +22,8 @@ use StyleCI\StyleCI\Models\Repo;
  */
 class RepoWasDisabledEvent
 {
+    use SerializesModels;
+
     /**
      * The repo that was disabled.
      *

--- a/app/Events/RepoWasEnabledEvent.php
+++ b/app/Events/RepoWasEnabledEvent.php
@@ -12,6 +12,7 @@
 
 namespace StyleCI\StyleCI\Events;
 
+use Illuminate\Queue\SerializesModels;
 use StyleCI\StyleCI\Models\Repo;
 
 /**
@@ -21,6 +22,8 @@ use StyleCI\StyleCI\Models\Repo;
  */
 class RepoWasEnabledEvent
 {
+    use SerializesModels;
+
     /**
      * The repo that was enabled.
      *

--- a/app/Events/UserHasRageQuitEvent.php
+++ b/app/Events/UserHasRageQuitEvent.php
@@ -12,6 +12,7 @@
 
 namespace StyleCI\StyleCI\Events;
 
+use Illuminate\Queue\SerializesModels;
 use StyleCI\StyleCI\Models\User;
 
 /**
@@ -21,6 +22,8 @@ use StyleCI\StyleCI\Models\User;
  */
 class UserHasRageQuitEvent
 {
+    use SerializesModels;
+
     /**
      * The user that has rage quit.
      *

--- a/app/Events/UserHasSignedUpEvent.php
+++ b/app/Events/UserHasSignedUpEvent.php
@@ -12,6 +12,7 @@
 
 namespace StyleCI\StyleCI\Events;
 
+use Illuminate\Queue\SerializesModels;
 use StyleCI\StyleCI\Models\User;
 
 /**
@@ -21,6 +22,8 @@ use StyleCI\StyleCI\Models\User;
  */
 class UserHasSignedUpEvent
 {
+    use SerializesModels;
+
     /**
      * The user that has signed up.
      *


### PR DESCRIPTION
By loading the SerializesModels trait into our events, any event handlers that implement ShouldBeQueued will now work correctly.