### PR TITLE
Adds a Shield route for handling badges

### DIFF
--- a/app/Http/Controllers/ShieldController.php
+++ b/app/Http/Controllers/ShieldController.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of StyleCI.
+ *
+ * (c) Graham Campbell <graham@mineuk.com>
+ * (c) Joseph Cohen <joseph.cohen@dinkbit.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace StyleCI\StyleCI\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redirect;
+use StyleCI\StyleCI\Models\Repo;
+
+/**
+ * This is the shield controller class.
+ *
+ * @author James Brooks <jbrooksuk@me.com>
+ */
+class ShieldController extends AbstractController
+{
+    /**
+     * Handles a request to serve a shield.
+     *
+     * @param \StyleCI\StyleCI\Models\Repo $repo
+     * @param \Illuminate\Http\Request     $request
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function handle(Repo $repo, Request $request)
+    {
+        $shieldUrl = $this->generateShieldUrl($repo, $request);
+
+        return Redirect::to($shieldUrl);
+    }
+
+    /**
+     * Generates a Shields.io URL.
+     *
+     * @param \Illuminate\Http\Request     $repo
+     * @param \StyleCI\StyleCI\Models\Repo $request
+     *
+     * @return string
+     */
+    protected function generateShieldUrl(Repo $repo, Request $request)
+    {
+        $url = 'https://img.shields.io/badge/%s-%s-%s.svg?style=%s';
+
+        $color = 'lightgrey';
+        $status = 'unknown';
+        if ($commit = $repo->commits()->where('ref', 'refs/heads/master')->orderBy('created_at', 'desc')->first()) {
+            $status = strtolower($commit->summary());
+            if ($commit->status === 1) {
+                $color = 'green';
+            } elseif ($commit->status === 2) {
+                $color = 'red';
+            }
+        }
+
+        return vsprintf($url, [
+            'StyleCI',
+            $status,
+            $color,
+            $request->get('style', ''),
+        ]);
+    }
+}

--- a/app/Http/Routes/RepoRoutes.php
+++ b/app/Http/Routes/RepoRoutes.php
@@ -40,6 +40,11 @@ class RepoRoutes
             'uses' => 'RepoController@handleShow'
         ]);
 
+        $router->get('repos/{repo}/shield', [
+            'as'   => 'repo_shield_path',
+            'uses' => 'ShieldController@handle'
+        ]);
+
         $router->post('repos/{repo}/analyse', [
             'as'   => 'repo_analyse_path',
             'uses' => 'RepoController@handleAnalyse'


### PR DESCRIPTION
For example: `http://styleci.io.dev/repos/30110021/shield?style=flat` will produce:

![image](https://cloud.githubusercontent.com/assets/246103/6266759/75bbf67c-b835-11e4-8441-2e596846a40c.png)

Whilst it's not had any commits, then it uses the `$commit->summary()` in lowercase to bring it back with the right status.