### PR TITLE
Split diff to files

### DIFF
--- a/app/Http/Controllers/CommitController.php
+++ b/app/Http/Controllers/CommitController.php
@@ -32,32 +32,7 @@ class CommitController extends AbstractController
      */
     public function handleShow(Commit $commit)
     {
-        // We first get the original and modified file names from the diff.
-        preg_match_all('/\-\-\-\sa\/(.*?.*)/i', $commit->diff, $originalNames);
-        preg_match_all('/\+\+\+\sb\/(.*?.*)/i', $commit->diff, $modifiedNames);
-
-        $fileNames = [];
-
-        // If the file name was modified we show the change.
-        foreach ($originalNames[1] as $key => $originalName) {
-            if ($originalName != $modifiedNames[1][$key]) {
-                $fileNames[] = $originalName.' -> '.$modifiedNames[1][$key];
-            } else {
-                $fileNames[] = $originalName;
-            }
-        }
-
-        // Then we split the diff into files.
-        $extractedFiles = preg_split("/\s+?diff ?/", ltrim($commit->diff));
-
-        $files = [];
-
-        // Match file names with files.
-        foreach ($extractedFiles as $index => $file) {
-            $files[$fileNames[$index]] = 'diff '.$file;
-        }
-
-        return View::make('commit', compact('commit', 'files'));
+        return View::make('commit', compact('commit'));
     }
 
     /**

--- a/app/Http/Controllers/CommitController.php
+++ b/app/Http/Controllers/CommitController.php
@@ -32,7 +32,32 @@ class CommitController extends AbstractController
      */
     public function handleShow(Commit $commit)
     {
-        return View::make('commit', compact('commit'));
+        // We first get the original and modified file names from the diff.
+        preg_match_all('/\-\-\-\sa\/(.*?.*)/i', $commit->diff, $originalNames);
+        preg_match_all('/\+\+\+\sb\/(.*?.*)/i', $commit->diff, $modifiedNames);
+
+        $fileNames = [];
+
+        // If the file name was modified we show the change.
+        foreach ($originalNames[1] as $key => $originalName) {
+            if ($originalName != $modifiedNames[1][$key]) {
+                $fileNames[] = $originalName.' -> '.$modifiedNames[1][$key];
+            } else {
+                $fileNames[] = $originalName;
+            }
+        }
+
+        // Then we split the diff into files.
+        $extractedFiles = preg_split("/\s+?diff ?/", ltrim($commit->diff));
+
+        $files = [];
+
+        // Match file names with files.
+        foreach ($extractedFiles as $index => $file) {
+            $files[$fileNames[$index]] = 'diff '.$file;
+        }
+
+        return View::make('commit', compact('commit', 'files'));
     }
 
     /**

--- a/app/Presenters/CommitPresenter.php
+++ b/app/Presenters/CommitPresenter.php
@@ -75,6 +75,47 @@ class CommitPresenter extends BasePresenter implements Arrayable
     }
 
     /**
+     * Get the diff splited to files.
+     *
+     * @return array
+     */
+    public function diffFiles()
+    {
+        if (trim($this->wrappedObject->diff) == '') {
+            return [];
+        }
+
+        $diff = ltrim($this->wrappedObject->diff);
+
+        // We first get the original and modified file names from the diff.
+        preg_match_all('/\-\-\-\sa\/(.*?.*)/i', $diff, $originalNames);
+        preg_match_all('/\+\+\+\sb\/(.*?.*)/i', $diff, $modifiedNames);
+
+        $fileNames = [];
+
+        // If the file name was modified we show the change.
+        foreach ($originalNames[1] as $key => $originalName) {
+            if ($originalName != $modifiedNames[1][$key]) {
+                $fileNames[] = $originalName.' -> '.$modifiedNames[1][$key];
+            } else {
+                $fileNames[] = $originalName;
+            }
+        }
+
+        // Then we split the diff into files.
+        $extractedFiles = preg_split("/\s+?diff ?/", $diff);
+
+        $files = [];
+
+        // Match file names with files.
+        foreach ($extractedFiles as $index => $file) {
+            $files[$fileNames[$index]] = 'diff '.$file;
+        }
+
+        return $files;
+    }
+
+    /**
      * Convert presented commit to an array.
      *
      * @return array

--- a/resources/views/commit.blade.php
+++ b/resources/views/commit.blade.php
@@ -39,9 +39,18 @@
     </div>
     @if ($commit->status === 2)
     <hr>
-    <pre class="brush: diff">
-        {{ $commit->diff }}
-    </pre>
+    @foreach ($files as $name => $file)
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            {{ $name }}
+        </div>
+        <div class="panel-body">
+            <pre class="brush: diff">
+                {{ $file }}
+            </pre>
+        </div>
+    </div>
+    @endforeach
     @endif
 </div>
 @stop

--- a/resources/views/commit.blade.php
+++ b/resources/views/commit.blade.php
@@ -39,7 +39,7 @@
     </div>
     @if ($commit->status === 2)
     <hr>
-    @foreach ($files as $name => $file)
+    @foreach ($commit->diffFiles() as $name => $file)
     <div class="panel panel-default">
         <div class="panel-heading">
             {{ $name }}


### PR DESCRIPTION
Split diff into files only to display them.

- Commit page loads faster.
- More readable.
- Check for modified file names.

//cc @GrahamCampbell @jbrooksuk @MichaelBanks 

![diff](https://cloud.githubusercontent.com/assets/1803556/6447884/b0a2ff16-c0db-11e4-8e6a-f9189312d806.png)
