### PR TITLE
Override description handling

### DIFF
--- a/app/Presenters/CommitPresenter.php
+++ b/app/Presenters/CommitPresenter.php
@@ -134,6 +134,16 @@ class CommitPresenter extends BasePresenter implements Arrayable
     }
 
     /**
+     * Get the commit status description.
+     *
+     * @return string
+     */
+    public function description()
+    {
+        return $this->wrappedObject->description();
+    }
+
+    /**
      * Convert presented commit to an array.
      *
      * @return array


### PR DESCRIPTION
Without this I get:
```
Relationship method must return an object of type Illuminate\Database\Eloquent\Relations\Relation (View: /web/styleci/dev/resources/views/commit.blade.php) 
```

Is there a better fix that could be made, maybe to auto-presenter?