### PR TITLE
Remove [StyleCI] from email subjects

### DIFF
--- a/app/Handlers/Events/Analysis/AnalysisNotificationsHandler.php
+++ b/app/Handlers/Events/Analysis/AnalysisNotificationsHandler.php
@@ -73,7 +73,7 @@ class AnalysisNotificationsHandler
             'repo'    => $repo->name,
             'commit'  => $analysis->message,
             'link'    => route('analysis_path', AutoPresenter::decorate($analysis)->id),
-            'subject' => '[StyleCI] Failed Analysis',
+            'subject' => 'Failed Analysis',
         ];
 
         switch ($analysis->status) {

--- a/app/Handlers/Events/Repo/RepoNotificationHandler.php
+++ b/app/Handlers/Events/Repo/RepoNotificationHandler.php
@@ -65,10 +65,10 @@ class RepoNotificationHandler
         $mail = ['repo' => $event->repo->name];
 
         if ($event instanceof RepoWasDisabledEvent) {
-            $mail['subject'] = '[StyleCI] Repo Disabled';
+            $mail['subject'] = 'Repo Disabled';
             $view = 'disabled';
         } else {
-            $mail['subject'] = '[StyleCI] Repo Enabled';
+            $mail['subject'] = 'Repo Enabled';
             $mail['link'] = route('repo_path', $event->repo->id);
             $view = 'enabled';
         }

--- a/app/Handlers/Events/User/GoodbyeMessageHandler.php
+++ b/app/Handlers/Events/User/GoodbyeMessageHandler.php
@@ -56,7 +56,7 @@ class GoodbyeMessageHandler
         $mail = [
             'email'   => $user->email,
             'name'    => AutoPresenter::decorate($user)->first_name,
-            'subject' => '[StyleCI] Your account has been removed from StyleCI',
+            'subject' => 'Your account has been removed from StyleCI',
         ];
 
         $this->mailer->queue(['html' => 'emails.goodbye-html', 'text' => 'emails.goodbye-text'], $mail, function (Message $message) use ($mail) {

--- a/app/Handlers/Events/User/WelcomeMessageHandler.php
+++ b/app/Handlers/Events/User/WelcomeMessageHandler.php
@@ -56,7 +56,7 @@ class WelcomeMessageHandler
         $mail = [
             'email'   => $user->email,
             'name'    => AutoPresenter::decorate($user)->first_name,
-            'subject' => '[StyleCI] Welcome To StyleCI',
+            'subject' => 'Welcome To StyleCI',
         ];
 
         $this->mailer->queue(['html' => 'emails.welcome-html', 'text' => 'emails.welcome-text'], $mail, function (Message $message) use ($mail) {


### PR DESCRIPTION
I've removed the `[StyleCI]` text from the email subjects. Next I need to redo the email design.