### PR TITLE
Flush analysis cache when a PR is merged or a branch is deleted

### DIFF
--- a/app/Handlers/Events/Repo/AnalysisCacheFlushHandler.php
+++ b/app/Handlers/Events/Repo/AnalysisCacheFlushHandler.php
@@ -1,0 +1,60 @@
+<?php
+
+/*
+ * This file is part of StyleCI.
+ *
+ * (c) Alt Three Services Limited
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace StyleCI\StyleCI\Handlers\Events\Repo;
+
+use StyleCI\Cache\CacheResolver;
+use StyleCI\StyleCI\Events\Repo\GitHub\GitHubDeleteEvent;
+use StyleCI\StyleCI\Events\Repo\GitHub\GitHubEventInterface;
+use StyleCI\StyleCI\Events\Repo\GitHub\GitHubPullRequestEvent;
+
+/**
+ * This is the analysis cache flush handler class.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ */
+class AnalysisCacheFlushHandler
+{
+    /**
+     * The cache resolver instance.
+     *
+     * @var \StyleCI\Cache\CacheResolver
+     */
+    protected $cache;
+
+    /**
+     * Create a new analysis cache flush handler instance.
+     *
+     * @param \StyleCI\Cache\CacheResolver $cache
+     *
+     * @return void
+     */
+    public function __construct(CacheResolver $cache)
+    {
+        $this->cache = $cache;
+    }
+
+    /**
+     * Handle the github repo event.
+     *
+     * @param \StyleCI\StyleCI\Events\Repo\GitHub\GitHubDeleteEvent|\StyleCI\StyleCI\Events\Repo\GitHub\GitHubPullRequestEvent $event
+     *
+     * @return void
+     */
+    public function handle(GitHubEventInterface $event)
+    {
+        if ($event instanceof GitHubDeleteEvent && $this->event->data['ref_type'] === 'branch') {
+            $this->cache->flush($event->repo->id, 'branch.'.$event->data['ref']);
+        } elseif ($event instanceof GitHubPullRequestEvent && $this->event->data['pull_request']['merged']) {
+            $this->cache->flush($event->repo->id, 'pr.'.$event->data['number']);
+        }
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -47,6 +47,7 @@ class EventServiceProvider extends ServiceProvider
         ],
         'StyleCI\StyleCI\Events\Repo\GitHub\GitHubDeleteEvent' => [
             'StyleCI\StyleCI\Handlers\Events\Repo\BranchCacheFlushHandler',
+            'StyleCI\StyleCI\Handlers\Events\Repo\AnalysisCacheFlushHandler',
             'StyleCI\StyleCI\Handlers\Events\Repo\PusherBranchHandler',
         ],
         'StyleCI\StyleCI\Events\Repo\GitHub\GitHubMemberEvent' => [
@@ -56,6 +57,7 @@ class EventServiceProvider extends ServiceProvider
             'StyleCI\StyleCI\Handlers\Events\Repo\GitHub\GitHubPingHandler',
         ],
         'StyleCI\StyleCI\Events\Repo\GitHub\GitHubPullRequestEvent' => [
+            'StyleCI\StyleCI\Handlers\Events\Repo\AnalysisCacheFlushHandler',
             'StyleCI\StyleCI\Handlers\Events\Repo\GitHub\GitHubPullRequestHandler',
         ],
         'StyleCI\StyleCI\Events\Repo\GitHub\GitHubPushEvent' => [


### PR DESCRIPTION
Note that we're not flushing when a PR is just closed, because the user might be closing and re-opening the PR. This closes #432 and closes #428.