### PR TITLE
Stop using quicksilver preview

### DIFF
--- a/app/GitHub/Branches.php
+++ b/app/GitHub/Branches.php
@@ -116,7 +116,7 @@ class Branches
      */
     protected function fetchFromGitHub(Repo $repo)
     {
-        $client = $this->factory->make($repo, ['version' => 'quicksilver-preview']);
+        $client = $this->factory->make($repo);
         $paginator = new ResultPager($client);
 
         return $paginator->fetchAll($client->repos(), 'branches', explode('/', $repo->name));

--- a/app/GitHub/Collaborators.php
+++ b/app/GitHub/Collaborators.php
@@ -76,7 +76,7 @@ class Collaborators
      */
     protected function fetchFromGitHub(User $user, $name)
     {
-        $client = $this->factory->make($user, ['version' => 'quicksilver-preview']);
+        $client = $this->factory->make($user);
         $paginator = new ResultPager($client);
 
         $list = [];

--- a/app/GitHub/Commits.php
+++ b/app/GitHub/Commits.php
@@ -51,7 +51,7 @@ class Commits
     {
         $args = explode('/', $repo->name);
 
-        $client = $this->factory->make($repo, ['version' => 'quicksilver-preview']);
+        $client = $this->factory->make($repo);
 
         return $client->repos()->commits()->show($args[0], $args[1], $commit);
     }

--- a/app/GitHub/Hooks.php
+++ b/app/GitHub/Hooks.php
@@ -51,7 +51,7 @@ class Hooks
     public function enable(Repo $repo)
     {
         $args = explode('/', $repo->name);
-        $hooks = $this->factory->make($repo, ['version' => 'quicksilver-preview'])->repo()->hooks();
+        $hooks = $this->factory->make($repo)->repo()->hooks();
 
         $events = ['create', 'delete', 'member', 'pull_request', 'push', 'team_add'];
 
@@ -76,7 +76,7 @@ class Hooks
     {
         $url = route('home');
         $args = explode('/', $repo->name);
-        $client = $this->factory->make($repo, ['version' => 'quicksilver-preview']);
+        $client = $this->factory->make($repo);
         $hooks = $client->repo()->hooks();
         $paginator = new ResultPager($client);
 

--- a/app/GitHub/Status.php
+++ b/app/GitHub/Status.php
@@ -61,7 +61,7 @@ class Status
             'context'     => 'StyleCI',
         ];
 
-        $client = $this->factory->make($repo, ['version' => 'quicksilver-preview']);
+        $client = $this->factory->make($repo);
 
         $client->repos()->statuses()->create($args[0], $args[1], $analysis->commit, $data);
     }


### PR DESCRIPTION
#### This is to be merged after GitHub move this preview into production.

> Last month, we announced the upcoming repository redirect behavior for the API, and we made it available for developers to preview. Starting July 21, 2015, the API will automatically provide these redirects for all API consumers.